### PR TITLE
Enhance Ordinator to support mouse-based line selection

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -16,12 +16,30 @@ function activate(context) {
     if (!editor) return; // No open text editor
 
     const selections = editor.selections;
+	let selectedLines = [];
 
-		if (selections.length < 2) {
-			return vscode.window.showErrorMessage(`Select more then one line to order`);
+		if (selections.length < 1) {
+			return vscode.window.showErrorMessage(`Select something to order`);
 		}
+
+		if (selections.length === 1) {
+			const selection = selections[0];
+
+			if(selection.isSingleLine){
+				return vscode.window.showErrorMessage(`Select more than one line to order`);
+			}
+
+			for (let lineNumber = selection.start.line; lineNumber <= selection.end.line; lineNumber++) {
+				const line = editor.document.lineAt(lineNumber);
+				const range = new vscode.Range(line.range.start, line.range.end);
+				selectedLines.push(range);
+			}
+		} else {
+			selectedLines = selections;
+		}
+
 		
-		const selectionsSorted = selections.slice().sort((a,b) => {
+		const selectionsSorted = selectedLines.slice().sort((a,b) => {
 			if(editor.document.getText(a).length > editor.document.getText(b).length) return 1;
 			if(editor.document.getText(a).length < editor.document.getText(b).length) return -1;
 			return 0;
@@ -30,7 +48,7 @@ function activate(context) {
 		selectionsSorted.forEach(s => console.log(editor.document.getText(s)))
 		
 		return editor.edit(builder => {
-			selections.forEach((selection, idx) => builder.replace(selection, editor.document.getText(selectionsSorted[idx])))
+			selectedLines.forEach((selection, idx) => builder.replace(selection, editor.document.getText(selectionsSorted[idx])))
 		});
 	});
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ordinator",
-  "version": "0.0.1",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ordinator",
-      "version": "0.0.1",
+      "version": "0.0.5",
       "devDependencies": {
         "@types/glob": "^8.1.0",
         "@types/mocha": "^10.0.1",


### PR DESCRIPTION
This PR improves the functionality of the "Ordinator" VSCode extension by adding support for mouse-based line selection. Previously, users had to manually select multiple lines, which made the process more complex by requiring many inputs. The updated functionality now allows greater flexibility, enabling selection with the mouse for both single and multiple lines.

### Key Changes:
1. **Improved Selection Handling:**
   - The extension now supports ordering multiple lines using a single selection (from a single cursor drag). There's no longer a need for multiple separate selections.
   - The logic has been extended to automatically handle all lines between the start and end of a single selection.

2. **Validation Enhancements:**
   - Error messages have been improved for better user guidance, with prompts such as "Select something to order" or "Select more than one line to order" depending on the user's input.

3. **Refactored Sorting Logic:**
   - The sorting mechanism still operates based on the length of the selected text but has been enhanced to ensure correct behavior with the new selection feature. The entire line is now taken into consideration, even if only part of a line is selected, ensuring text integrity during ordering.

These enhancements significantly improve usability, making the extension more intuitive, particularly for users who prefer mouse-based interaction for selecting lines.